### PR TITLE
Add idempotency docs and stop-slop writing skill

### DIFF
--- a/.claude/skills/stop-slop/CHANGELOG.md
+++ b/.claude/skills/stop-slop/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 2026-01-13
+
+### Added
+
+**Phrases (references/phrases.md)**
+- Throat-clearing: "Here's what I find interesting", "Here's the problem though"
+- Performative emphasis: "creeps in", "I promise", "They exist, I promise"
+- Telling instead of showing: "This is genuinely hard", "This is what leadership actually looks like"
+
+**Structures (references/structures.md)**
+- Binary contrasts: "Not X. But Y.", "It's not this. It's that.", "stops being X and starts being Y"
+- Rhythm patterns: staccato fragmentation, dashes for dramatic pause, hedging as reassurance
+- Word patterns: absolute words (always, never, everyone, etc.), AI-overused intensifiers (deeply, truly, fundamentally, inherently, simply, literally, inevitably)
+
+## 2026-01-12
+
+- Restructured skill following Claude Code best practices (PR #1)
+- Split into SKILL.md and references/ folder
+
+## 2025-01-12
+
+- Initial release

--- a/.claude/skills/stop-slop/LICENSE
+++ b/.claude/skills/stop-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Hardik Pandya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/stop-slop/README.md
+++ b/.claude/skills/stop-slop/README.md
@@ -1,0 +1,62 @@
+# Stop Slop
+
+A skill for removing AI tells from prose.
+
+<img width="3840" height="2160" alt="G-Yg4RVbIAAhVxW" src="https://github.com/user-attachments/assets/902afc15-1f40-4a9d-af24-8cd67afb8ebf" />
+
+## What this is
+
+AI writing has patterns. Predictable phrases, structures, rhythms. This skill teaches Claude (or any LLM) to catch and remove them.
+
+## Skill Structure
+
+```
+stop-slop/
+├── SKILL.md              # Core instructions
+├── references/
+│   ├── phrases.md        # Phrases to remove
+│   ├── structures.md     # Structural patterns to avoid
+│   └── examples.md       # Before/after transformations
+├── README.md
+└── LICENSE
+```
+
+## Quick start
+
+**Claude Code:** Add this folder as a skill.
+
+**Claude Projects:** Upload `SKILL.md` and reference files to project knowledge.
+
+**Custom instructions:** Copy core rules from `SKILL.md`.
+
+**API calls:** Include `SKILL.md` in your system prompt. Reference files load on demand.
+
+## What it catches
+
+**Banned phrases** - Throat-clearing openers, emphasis crutches, business jargon, all adverbs, vague declaratives, meta-commentary. See `references/phrases.md`.
+
+**Structural clichés** - Binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency, narrator-from-a-distance voice, passive voice. See `references/structures.md`.
+
+**Sentence-level rules** - No Wh- sentence starters, no em dashes, no staccato fragmentation, no lazy extremes, active voice required.
+
+## Scoring
+
+Rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds human? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Author
+
+[Hardik Pandya](https://hvpandya.com)
+
+## License
+
+MIT. Use freely, share widely.

--- a/.claude/skills/stop-slop/SKILL.md
+++ b/.claude/skills/stop-slop/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: stop-slop
+description: Remove AI writing patterns from prose. Use when drafting, editing, or reviewing text to eliminate predictable AI tells.
+metadata:
+  trigger: Writing prose, editing drafts, reviewing content for AI patterns
+  author: Hardik Pandya (https://hvpandya.com)
+---
+
+# Stop Slop
+
+Eliminate predictable AI writing patterns from prose.
+
+## Core Rules
+
+1. **Cut filler phrases.** Remove throat-clearing openers, emphasis crutches, and all adverbs. See [references/phrases.md](references/phrases.md).
+
+2. **Break formulaic structures.** Avoid binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency. See [references/structures.md](references/structures.md).
+
+3. **Use active voice.** Every sentence needs a human subject doing something. No passive constructions. No inanimate objects performing human actions ("the complaint becomes a fix").
+
+4. **Be specific.** No vague declaratives ("The reasons are structural"). Name the specific thing. No lazy extremes ("every," "always," "never") doing vague work.
+
+5. **Put the reader in the room.** No narrator-from-a-distance voice. "You" beats "People." Specifics beat abstractions.
+
+6. **Vary rhythm.** Mix sentence lengths. Two items beat three. End paragraphs differently. No em dashes.
+
+7. **Trust readers.** State facts directly. Skip softening, justification, hand-holding.
+
+8. **Cut quotables.** If it sounds like a pull-quote, rewrite it.
+
+## Quick Checks
+
+Before delivering prose:
+
+- Any adverbs? Kill them.
+- Any passive voice? Find the actor, make them the subject.
+- Inanimate thing doing a human verb ("the decision emerges")? Name the person.
+- Sentence starts with a Wh- word? Restructure it.
+- Any "here's what/this/that" throat-clearing? Cut to the point.
+- Any "not X, it's Y" contrasts? State Y directly.
+- Three consecutive sentences match length? Break one.
+- Paragraph ends with punchy one-liner? Vary it.
+- Em-dash anywhere? Remove it.
+- Vague declarative ("The implications are significant")? Name the specific implication.
+- Narrator-from-a-distance ("Nobody designed this")? Put the reader in the scene.
+- Meta-joiners ("The rest of this essay...")? Delete. Let the essay move.
+
+## Scoring
+
+Rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds human? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Examples
+
+See [references/examples.md](references/examples.md) for before/after transformations.
+
+## License
+
+MIT

--- a/.claude/skills/stop-slop/references/examples.md
+++ b/.claude/skills/stop-slop/references/examples.md
@@ -1,0 +1,59 @@
+# Before/After Examples
+
+## Example 1: Throat-Clearing + Binary Contrast
+
+**Before:**
+> "Here's the thing: building products is hard. Not because the technology is complex. Because people are complex. Let that sink in."
+
+**After:**
+> "Building products is hard. Technology is manageable. People aren't."
+
+**Changes:** Removed opener, binary contrast structure, and emphasis crutch. Direct statements.
+
+---
+
+## Example 2: Filler + Unnecessary Reassurance
+
+**Before:**
+> "It turns out that most teams struggle with alignment. The uncomfortable truth is that nobody wants to admit they're confused. And that's okay."
+
+**After:**
+> "Teams struggle with alignment. Nobody admits confusion."
+
+**Changes:** Cut hedging ("most"), removed throat-clearing phrases, deleted permission-granting ending.
+
+---
+
+## Example 3: Business Jargon Stack
+
+**Before:**
+> "In today's fast-paced landscape, we need to lean into discomfort and navigate uncertainty with clarity. This matters because your competition isn't waiting."
+
+**After:**
+> "Move faster. Your competition is."
+
+**Changes:** Eliminated jargon entirely. Core message in six words.
+
+---
+
+## Example 4: Dramatic Fragmentation
+
+**Before:**
+> "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
+
+**After:**
+> "Speed, quality, cost—pick two."
+
+**Changes:** Single sentence. No performative emphasis.
+
+---
+
+## Example 5: Rhetorical Setup
+
+**Before:**
+> "What if I told you that the best teams don't optimize for productivity? Here's what I mean: they optimize for learning. Think about it."
+
+**After:**
+> "The best teams optimize for learning, not productivity."
+
+**Changes:** Direct claim. No rhetorical scaffolding.

--- a/.claude/skills/stop-slop/references/phrases.md
+++ b/.claude/skills/stop-slop/references/phrases.md
@@ -1,0 +1,128 @@
+# Phrases to Remove
+
+## Throat-Clearing Openers
+
+Remove these announcement phrases. State the content directly.
+
+- "Here's the thing:"
+- "Here's what [X]"
+- "Here's this [X]"
+- "Here's that [X]"
+- "Here's why [X]"
+- "The uncomfortable truth is"
+- "It turns out"
+- "The real [X] is"
+- "Let me be clear"
+- "The truth is,"
+- "I'll say it again:"
+- "I'm going to be honest"
+- "Can we talk about"
+- "Here's what I find interesting"
+- "Here's the problem though"
+
+Any "here's what/this/that" construction is throat-clearing before the point. Cut it and state the point.
+
+## Emphasis Crutches
+
+These add no meaning. Delete them.
+
+- "Full stop." / "Period."
+- "Let that sink in."
+- "This matters because"
+- "Make no mistake"
+- "Here's why that matters"
+
+## Business Jargon
+
+Replace with plain language.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Navigate (challenges) | Handle, address |
+| Unpack (analysis) | Explain, examine |
+| Lean into | Accept, embrace |
+| Landscape (context) | Situation, field |
+| Game-changer | Significant, important |
+| Double down | Commit, increase |
+| Deep dive | Analysis, examination |
+| Take a step back | Reconsider |
+| Moving forward | Next, from now |
+| Circle back | Return to, revisit |
+| On the same page | Aligned, agreed |
+
+## Adverbs
+
+Kill all adverbs. No -ly words. No softeners, no intensifiers, no hedges.
+
+Specific offenders:
+
+- "really"
+- "just"
+- "literally"
+- "genuinely"
+- "honestly"
+- "simply"
+- "actually"
+- "deeply"
+- "truly"
+- "fundamentally"
+- "inherently"
+- "inevitably"
+- "interestingly"
+- "importantly"
+- "crucially"
+
+Also cut these filler phrases:
+
+- "At its core"
+- "In today's [X]"
+- "It's worth noting"
+- "At the end of the day"
+- "When it comes to"
+- "In a world where"
+- "The reality is"
+
+## Meta-Commentary
+
+Remove self-referential asides. The essay should move, not announce its own structure.
+
+- "Hint:"
+- "Plot twist:" / "Spoiler:"
+- "You already know this, but"
+- "But that's another post"
+- "X is a feature, not a bug"
+- "Dressed up as"
+- "The rest of this essay explains..."
+- "Let me walk you through..."
+- "In this section, we'll..."
+- "As we'll see..."
+- "I want to explore..."
+
+## Performative Emphasis
+
+False intimacy or manufactured sincerity:
+
+- "creeps in"
+- "I promise"
+- "They exist, I promise"
+
+## Telling Instead of Showing
+
+Announcing difficulty or significance rather than demonstrating it:
+
+- "This is genuinely hard"
+- "This is what leadership actually looks like"
+- "This is what X actually looks like"
+- "actually matters"
+
+## Vague Declaratives
+
+Sentences that announce importance without naming the specific thing. Kill these.
+
+- "The reasons are structural"
+- "The implications are significant"
+- "This is the deepest problem"
+- "The stakes are high"
+- "The consequences are real"
+
+If a sentence says something is important/deep/structural without showing the specific thing, cut it or replace it with the specific thing.

--- a/.claude/skills/stop-slop/references/structures.md
+++ b/.claude/skills/stop-slop/references/structures.md
@@ -1,0 +1,134 @@
+# Structures to Avoid
+
+## Binary Contrasts
+
+These create false drama. State the point directly.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not because X. Because Y." / "Not because X, but because Y." | Telegraphed reversal |
+| "[X] isn't the problem. [Y] is." | Formulaic reframe |
+| "The answer isn't X. It's Y." | Predictable pivot |
+| "It feels like X. It's actually Y." | Setup/reveal cliche |
+| "The question isn't X. It's Y." | Rhetorical misdirection |
+| "Not X. But Y." / "not X, it's Y" / "isn't X, it's Y" | Mechanical contrast |
+| "It's not this. It's that." | Same formula, different words |
+| "stops being X and starts being Y" | False transformation arc |
+| "doesn't mean X, but actually Y" | Negation-then-assertion crutch |
+| "is about X but not Y" | False distinction |
+| "not just X but also Y" | Additive hedge |
+
+**Instead:** State Y directly. "The problem is Y." "Y matters here." Drop the negation entirely.
+
+## Negative Listing
+
+Listing what something is *not* before revealing what it *is*. A rhetorical striptease.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not a X... Not a Y... A Z." | Dramatic buildup through negation |
+| "It wasn't X. It wasn't Y. It was Z." | Same structure, past tense |
+
+**Instead:** State Z. The reader doesn't need the runway.
+
+## Dramatic Fragmentation
+
+Sentence fragments for emphasis read as manufactured profundity.
+
+| Pattern | Problem |
+|---------|---------|
+| "[Noun]. That's it. That's the [thing]." | Performative simplicity |
+| "X. And Y. And Z." | Staccato drama |
+| "This unlocks something. [Word]." | Artificial revelation |
+
+**Instead:** Complete sentences. Trust content over presentation.
+
+## Rhetorical Setups
+
+These announce insight rather than deliver it.
+
+| Pattern | Problem |
+|---------|---------|
+| "What if [reframe]?" | Socratic posturing |
+| "Here's what I mean:" | Redundant preview |
+| "Think about it:" | Condescending prompt |
+| "And that's okay." | Unnecessary permission |
+
+**Instead:** Make the point. Let readers draw conclusions.
+
+## Formulaic Constructions
+
+| Pattern | Problem |
+|---------|---------|
+| "By the time X, I was Y." | Narrative template |
+| "X that isn't Y" | Indirect. Say "X is broken" |
+
+## False Agency
+
+Giving inanimate things human verbs. Complaints don't "become" fixes. Bets don't "live or die." Decisions don't "emerge." A person does something to make those things happen. AI loves this because it avoids naming the actor.
+
+| Pattern | Problem |
+|---------|---------|
+| "a complaint becomes a fix" | The complaint did nothing. Someone fixed it. |
+| "a bet lives or dies in days" | Bets don't have lifespans. Someone kills the project or ships it. |
+| "the decision emerges" | Decisions don't emerge. Someone decides. |
+| "the culture shifts" | Cultures don't shift on their own. People change behavior. |
+| "the conversation moves toward" | Conversations don't move. Someone steers. |
+| "the data tells us" | Data sits there. Someone reads it and draws a conclusion. |
+| "the market rewards" | Markets don't reward. Buyers pay for things. |
+
+**Instead:** Name the human. "The team fixed it that week" beats "the complaint becomes a fix." If no specific person fits, use "you" to put the reader in the seat.
+
+## Narrator-from-a-Distance
+
+Floating above the scene instead of putting the reader in it.
+
+| Pattern | Problem |
+|---------|---------|
+| "Nobody designed this." | Disembodied observation |
+| "This happens because..." | Lecturer voice |
+| "This is why..." | Same |
+| "People tend to..." | Armchair sociologist |
+
+**Instead:** Put the reader in the room. "You don't sit down one day and decide to..." beats "Nobody designed this."
+
+## Passive Voice
+
+Every sentence needs a subject doing something. Passive voice hides the actor and drains energy.
+
+| Pattern | Fix |
+|---------|-----|
+| "X was created" | Name who created it |
+| "It is believed that" | Name who believes it |
+| "Mistakes were made" | Name who made them |
+| "The decision was reached" | Name who decided |
+
+**Instead:** Find the actor. Put them at the front of the sentence.
+
+## Sentence Starters to Avoid
+
+| Pattern | Fix |
+|---------|-----|
+| Sentences starting with What, When, Where, Which, Who, Why, How | Restructure. Lead with the subject or the verb. |
+| Paragraphs starting with "So" | Start with content |
+| Sentences starting with "Look," | Remove |
+
+Wh- openers become a crutch. "What makes this hard is..." becomes "The constraint is..." or better, name the specific constraint.
+
+## Rhythm Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| Three-item lists | Use two items or one |
+| Questions answered immediately | Let questions breathe or cut them |
+| Every paragraph ends punchily | Vary endings |
+| Em-dashes | Remove. Use commas or periods. No em dashes at all. |
+| Staccato fragmentation | Don't stack short punchy sentences |
+| "Not always. Not perfectly." | Hedging disguised as reassurance |
+
+## Word Patterns
+
+| Pattern | Problem |
+|---------|---------|
+| Lazy extremes (every, always, never, everyone, everybody, nobody) | False authority. Use specifics instead of sweeping claims. |
+| All adverbs (-ly words, "really," "just," "literally," "genuinely," "honestly," "simply," "actually") | Empty emphasis. See phrases.md for full list. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ The mechanism uses placeholder markers in the template that get resolved by `gen
 4. `gen.sh` post-processes with sed to replace markers with relative Hugo URLs (`../slug/`)
 5. The FILEREF sed script is built from the same `PAGES` array, mapping `anchor(proto_path)` -> `../slug/`
 
+## Writing Style
+
+All prose in this repo must follow the stop-slop skill (`.claude/skills/stop-slop/`). Key rules: no adverbs, no passive voice, no filler phrases, no false agency, no three-item lists. Run `/stop-slop` on any new or edited documentation before committing.
+
 ## Commands
 
 - Generate docs: `./_gen/gen.sh`

--- a/content/docs/integration-guidance/idempotency.md
+++ b/content/docs/integration-guidance/idempotency.md
@@ -1,0 +1,60 @@
+---
+weight: 302
+title: "Idempotency"
+description: ""
+icon: "article"
+date: "2026-04-09T00:00:00+02:00"
+lastmod: "2026-04-09T00:00:00+02:00"
+draft: false
+toc: true
+---
+
+Connections drop. Requests time out. The network retries with exponential backoff, so your endpoint may receive the same request more than once.
+
+If your system treats a duplicate as an error, the network believes the operation failed. In payments, this causes stuck transactions or double payouts.
+
+The T-0 Network solves this through idempotency: **every request that changes state can be safely retried without causing duplicate side effects.**
+
+## How Retry Safety Works
+
+The network delivers every request at least once. If a response is lost due to a connection failure, the network resends the same request with the same identifiers.
+
+Your system applies the business effect once and returns the same result on every subsequent attempt. The combination of at-least-once delivery and idempotent receivers produces exactly-once processing without complex coordination protocols.
+
+Both the network and every provider must uphold their side of this contract for the guarantee to hold.
+
+## Three Rules for Providers
+
+### 1. Return the Original Response for Completed Requests
+
+When you receive a request with an identifier you have already processed, return the stored response. The caller needs to know what happened, not that the request arrived twice.
+
+**Wrong:** The network sends a payout request with `payment_id=123`. You process it and determine that a manual AML review is needed, so you return `ManualAmlCheck`. The network never receives your response because the connection drops. The network retries the same payout request with `payment_id=123`. You return `{"failed": {"details": "Payment has already been processed"}}`. The network treats this as a real failure and aborts the payment. The payment is now stuck: you are performing an AML review, but the network recorded a failure.
+
+**Right:** Same scenario. On the retry, you look up `payment_id=123`, find it in the AML review state, and return `ManualAmlCheck` again. The network knows the payment is pending review. The flow continues.
+
+### 2. Return Current Status for In-Flight Requests
+
+If the original request is still being processed when a duplicate arrives, return the current state. Do not block until completion and do not reject the request.
+
+For example, if a payout is waiting on a compliance check, return the pending compliance status. The network uses this to track progress and make routing decisions.
+
+### 3. Never Treat a Duplicate as an Error
+
+A duplicate request is a normal event caused by network retries or message redelivery. Returning an error for a duplicate breaks the retry contract and causes cascading failures in payment flows.
+
+Your system should distinguish between an invalid request and a repeated valid one. The request identifier (such as `payment_id`) tells you which case you are handling.
+
+## Request Categories
+
+Every network method declares one of two idempotency levels:
+
+**IDEMPOTENT** — The request changes state (creates a payment, initiates a payout). Your system must deduplicate based on the business identifier in the request body. Retrying produces the same outcome as the original call.
+
+**NO_SIDE_EFFECTS** — The request is read-only (fetching a quote, checking payment status). No deduplication is needed. These methods are safe for aggressive retry policies and caching strategies.
+
+## What This Means for Your Integration
+
+- **Build retry-safe endpoints.** Store the result of every state-changing operation and return it when the same identifier appears again.
+- **Use business identifiers for deduplication.** Each request carries a field (like `payment_id`) that uniquely identifies the operation. Use it as your deduplication key.
+- **Keep responses available for the lifetime of the resource.** Payment data has regulatory retention requirements. The stored response should remain retrievable for as long as the underlying resource exists.

--- a/content/docs/integration-guidance/idempotency.md
+++ b/content/docs/integration-guidance/idempotency.md
@@ -33,11 +33,13 @@ When you receive a request with an identifier you have already processed, return
 
 **Right:** Same scenario. On the retry, you look up `payment_id=123`, find it in the AML review state, and return `ManualAmlCheck` again. The network knows the payment is pending review. The flow continues.
 
-### 2. Return Current Status for In-Flight Requests
+### 2. Wait for Completion on In-Flight Requests
 
-If the original request is still being processed when a duplicate arrives, return the current state. Do not block until completion and do not reject the request.
+If your system has not yet returned a response for the original request when a duplicate arrives, wait for it to complete and return the same response for both requests. Do not reject the duplicate and do not return an error. 
 
-For example, if a payout is waiting on a compliance check, return the pending compliance status. The network uses this to track progress and make routing decisions.
+**Wrong:** The network sends a payout request with `payment_id=456`. You begin processing it. The network retries before you finish. You return `{"failed":{"details": "Request is already being processed"}}`. The network treats this as a failure and aborts the payment.
+
+**Right:** Same scenario. On the retry, you look up `payment_id=456` and see that it has not yet produced a response. You wait for it to complete, then return the same result for both requests.
 
 ### 3. Never Treat a Duplicate as an Error
 

--- a/content/docs/integration-guidance/introduction.md
+++ b/content/docs/integration-guidance/introduction.md
@@ -9,45 +9,37 @@ draft: false
 toc: true
 ---
 
-Payment providers can integrate with the T-0 Network through two primary approaches: using the provided Software Development Kit (SDK) for simplified integration, or implementing the underlying protocols directly for maximum flexibility and control. Both approaches utilize the Connect RPC framework, which provides native support for both gRPC and REST/JSON encoding, allowing providers to choose the communication protocol that best fits their existing infrastructure.
+Payment providers integrate with the T-0 Network in two ways: through the SDK, or by implementing the protocols directly. Both use the Connect RPC framework, which supports gRPC and REST/JSON encoding.
 
-The integration process requires implementing both client-side capabilities for calling network services and server-side endpoints for receiving network callbacks. All communications within the network utilize cryptographic signatures for authentication and integrity verification, ensuring secure and verifiable message exchange between all participants.
+You will implement client-side calls to network services and server-side endpoints that receive network callbacks. All communication uses cryptographic signatures for authentication and integrity verification.
 
 ## API Endpoints
 * Production: `https://api.t-0.network`
 * Sandbox: `https://api-sandbox.t-0.network`
 
 ## Idempotency and Request Safety
-All network RPC methods specify idempotency levels to ensure safe retry behavior and prevent duplicate processing. Methods marked as IDEMPOTENT can be safely retried multiple times with the same parameters without causing additional side effects.
-
-Methods marked as NO_SIDE_EFFECTS, such as GetPayoutQuote, can be called multiple times without any system state changes, making them safe for aggressive retry policies and caching strategies.
-
-This idempotency design enables robust error handling and retry mechanisms while preventing issues such as duplicate payments or incorrect credit usage accounting that could result from network interruptions or service restarts.
+All network methods specify idempotency levels for safe retry behavior and duplicate prevention. See [Idempotency](idempotency) for the full reliability contract and provider implementation requirements.
 
 ## SDK Integration Approach
-The T-0 Network SDK provides the most streamlined integration path for payment providers, abstracting the complexity of protocol implementation and cryptographic operations. The SDK is currently available for Go programming language, with additional language support available upon request for specific integration requirements.
+The SDK is the fastest integration path. It handles request signing, signature verification, and key management for you. The Go SDK is available now; additional languages are available on request.
 
-The SDK handles all cryptographic operations automatically, including request signing, signature verification, and key management. This approach significantly reduces the implementation complexity for providers while ensuring compliance with network security requirements. The SDK also provides built-in error handling, retry logic, and connection management to ensure robust operation in production environments.
-
-When using the SDK, providers implement callback handlers for network-initiated operations such as payout requests and payment status updates. The SDK framework manages the underlying HTTP server functionality, allowing providers to focus on business logic implementation rather than protocol details.
+With the SDK, you write callback handlers for network-initiated operations like payout requests and payment status updates. The SDK manages the HTTP server, retry logic, and connection lifecycle. You focus on business logic.
 
 ## Protocol Implementation Approach
-For providers requiring maximum control over their integration or operating in environments where SDK usage is not feasible, direct protocol implementation provides complete flexibility. This approach requires implementing both the client-side and server-side aspects of the Connect RPC protocol while managing cryptographic operations manually.
+If you need full control or cannot use the SDK, implement the Connect RPC protocol directly. You manage both client-side and server-side aspects, including cryptographic operations.
 
 ### gRPC Protocol Implementation
-The gRPC implementation provides high-performance, strongly-typed communication between providers and the network. gRPC's binary protocol encoding offers superior efficiency compared to JSON-based alternatives, making it particularly suitable for high-volume payment processing environments.
+gRPC uses binary encoding for high-throughput, strongly-typed communication. It is well suited for high-volume payment processing.
 
-When implementing gRPC integration, providers must generate client and server stubs from the provided protocol buffer definitions. The network.proto file defines the NetworkService interface that providers call to interact with the network, while the provider.proto file defines the ProviderService interface that providers must implement to receive network callbacks.
+Generate client and server stubs from the provided protocol buffer definitions. `network.proto` defines the NetworkService interface you call; `provider.proto` defines the ProviderService interface you implement to receive callbacks.
 
-gRPC implementation requires careful attention to connection management, particularly for long-lived connections used for streaming operations. Providers should implement appropriate retry logic and circuit breaker patterns to handle network interruptions and service unavailability scenarios.
+Pay attention to connection management for long-lived streaming connections. Implement retry logic and circuit breaker patterns for network interruptions.
 
-The gRPC approach provides excellent tooling support across multiple programming languages and integrates well with modern microservices architectures. The strongly-typed nature of gRPC interfaces helps prevent integration errors and provides clear API contracts between providers and the network.
+gRPC tooling covers most programming languages and fits well in microservices architectures. Strongly-typed interfaces enforce clear API contracts and catch integration errors at compile time.
 
 ### REST/JSON Protocol Implementation
-The REST/JSON implementation offers broader compatibility and easier debugging compared to gRPC, making it suitable for providers with existing REST-based architectures or those requiring human-readable message formats for monitoring and troubleshooting.
+REST/JSON offers broader compatibility and human-readable messages, making it easier to debug and monitor. It suits providers with existing REST-based architectures.
 
-REST/JSON implementation uses standard HTTP methods and JSON message encoding, following RESTful design principles. The Connect RPC framework automatically generates REST endpoints corresponding to each gRPC service method, maintaining consistent functionality across both protocol options.
+The Connect RPC framework generates REST endpoints for each gRPC service method. Both protocols share the same functionality. JSON message formats follow the protocol buffer JSON mapping specification, so gRPC and REST implementations stay consistent.
 
-When implementing REST/JSON integration, providers must carefully handle HTTP status codes, error responses, and content negotiation. The JSON message format follows the protocol buffer JSON mapping specification, ensuring consistency with gRPC implementations while providing human-readable message content.
-
-REST implementation provides excellent debugging capabilities through standard HTTP debugging tools and offers straightforward integration with web-based monitoring and analytics platforms. The stateless nature of REST also simplifies load balancing and horizontal scaling of provider services.
+Handle HTTP status codes, error responses, and content negotiation in your implementation. REST's stateless model simplifies load balancing and horizontal scaling.


### PR DESCRIPTION
## Summary
- New customer-facing idempotency page under Integration Guidance covering retry safety, three provider rules (return original response, return in-flight status, never error on duplicates), and request categories
- Trimmed existing idempotency section in introduction.md to a one-line summary with link to the new page
- Applied stop-slop writing rules across introduction.md (cut passive voice, adverbs, filler — ~40% word count reduction)
- Added stop-slop skill to `.claude/skills/` and referenced it in CLAUDE.md

## Test plan
- [ ] Verify idempotency page renders in sidebar under Integration Guidance (between Introduction and API Reference)
- [ ] Verify link from introduction.md resolves to the new idempotency page
- [ ] Review idempotency content for business-level clarity (no database/proto internals exposed)
- [ ] Review introduction.md rewrites for accuracy after stop-slop pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)