### PR TITLE
ci: pin GOPROXY to public proxy to fix flaky gopkg.in module fetch

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -10,6 +10,10 @@ on:
 jobs:
   generate:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      # Same gopkg.in direct-git fragility as the Hugo deploy: route module
+      # fetches through the reliable public proxy.
+      GOPROXY: https://proxy.golang.org,direct
     steps:
       - name: Generate GitHub APP Token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -19,6 +19,10 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       HUGO_VERSION: 0.157.0
+      # Force module fetches through the public proxy. The Blacksmith runner's
+      # GOPROXY otherwise falls through to direct git against the flaky gopkg.in
+      # (502s), which protoc-gen-doc's legacy deps still resolve from.
+      GOPROXY: https://proxy.golang.org,direct
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
## Problem

The **Deploy Hugo site to Pages** workflow failed on `master` ([run 27831848340](https://github.com/t-0-network/t-0-network.github.io/actions/runs/27831848340/job/82370309719)). The *Build with Hugo* step died collecting Go modules:

```
gopkg.in/yaml.v2@v2.2.2: reading gopkg.in/yaml.v2/go.mod at revision v2.2.2:
git ls-remote ... https://gopkg.in/yaml.v2 ... exit status 128:
fatal: unable to access 'https://gopkg.in/yaml.v2/': The requested URL returned error: 502
```

## Root cause

- Hugo manages theme modules through Go modules, so `hugo` runs `go mod download` over the **whole** root `go.mod` graph.
- `go.mod` pins `protoc-gen-doc` as a `tool`, dragging in legacy transitive deps (`grpc@v1.40.0` → `go-control-plane` → `testify@v1.5.1` → `gopkg.in/yaml.v2@v2.2.2`) that the site never uses.
- Go's default `GOPROXY` is `proxy.golang.org,direct`, but the failed step fetched via **direct `git ls-remote`** against `gopkg.in` — meaning the Blacksmith runner's `GOPROXY` falls through to direct git for these old `gopkg.in` modules. `gopkg.in` is a flaky redirector and returned a transient `502`.

## Fix

Set `GOPROXY: https://proxy.golang.org,direct` at job level in both Go-using workflows. A workflow-level `env` takes precedence over the runner default, routing fetches through the immutable public proxy instead of direct git. Verified the proxy serves the failing modules (`gopkg.in/yaml.v2@v2.2.2` `.info`/`.mod` → `200`, `grpc@v1.40.0` → `200`).

- `hugo.yaml` — the workflow that failed.
- `generate.yaml` — preventive; it runs `go install protoc-gen-doc` + `gen.sh` on the same runners and shares the exact fragility.

No `go.mod` / `go.sum` change — checksums stay valid and are still verified against `sum.golang.org`.

## Verify

Trigger *Deploy Hugo site to Pages* via `workflow_dispatch` on this branch (or on merge): the *Build with Hugo* step should collect modules with no `git ls-remote .../gopkg.in` line and reach *Upload artifact*.

## Follow-up (not in this PR)

The Hugo build still resolves `protoc-gen-doc`'s entire unused dependency tree (~58s "collected modules"). Isolating the doc-gen tool into its own module would strip these legacy deps from the deploy path and speed builds up, but touches the documented setup, so it's deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)