### PR TITLE
ci: route Hugo module downloads through the public proxy

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,6 +3,10 @@ languageCode = 'en-us'
 title = 't-0 Network'
 
 [module]
+    # Hugo Modules use their own proxy (default "direct" = git/VCS) and ignore the
+    # GOPROXY env. Point it at the public proxy so module downloads are zips, not
+    # git — the legacy protoc-gen-doc dep chain flakes on `git fetch --unshallow`.
+    proxy = "https://proxy.golang.org"
     [[module.imports]]
         path = "github.com/colinwilson/lotusdocs"
         disable = false


### PR DESCRIPTION
Pins `[module] proxy = "https://proxy.golang.org"` in hugo.toml. Hugo's module proxy was `direct` (git), so the legacy protoc-gen-doc dep chain was fetched via git and flakes on `git fetch --unshallow` on any cold build (cache eviction / go.sum change). Deploys pass today only because the module cache is warm — this removes the latent failure. Same fix already in usdt-pay-docs. Build output is unchanged (only the fetch path changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)